### PR TITLE
added textModel and textParser for titles and texts

### DIFF
--- a/src/Exception/LocaleNotSupportedException.php
+++ b/src/Exception/LocaleNotSupportedException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SurveyJsPhpSdk\Exception;
+
+class LocaleNotSupportedException extends \Exception
+{
+    public function __construct($locale = "", $code = 0, \Throwable $previous = null)
+    {
+        $message = 'Locale "' . $locale . '" is not supported';
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/src/Localization/Localization.php
+++ b/src/Localization/Localization.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SurveyJsPhpSdk\Localization;
+
+abstract class Localization
+{
+    /**
+     * @var []
+     * @description: list of supported locales ( check updates here https://github.com/surveyjs/survey-creator/tree/master/src/localization )
+     */
+    public const LOCALES = [
+        'ar',
+        'bg',
+        'ca',
+        'cs',
+        'da',
+        'de',
+        'en',
+        'es',
+        'et',
+        'fa',
+        'fi',
+        'fr',
+        'gr',
+        'he',
+        'hu',
+        'id',
+        'is',
+        'it',
+        'ja',
+        'ka',
+        'ko',
+        'lt',
+        'lv',
+        'nl',
+        'no',
+        'pl',
+        'pt',
+        'ro',
+        'ru',
+        'sv',
+        'sw',
+        'tg',
+        'th',
+        'tr',
+        'ua',
+        'zh-cn',
+        'zh-tw'
+    ];
+}

--- a/src/Localization/Localization.php
+++ b/src/Localization/Localization.php
@@ -5,46 +5,231 @@ namespace SurveyJsPhpSdk\Localization;
 abstract class Localization
 {
     /**
+     * @var string
+     */
+    public const AR = 'ar';
+
+    /**
+     * @var string
+     */
+    public const BG = 'bg';
+
+    /**
+     * @var string
+     */
+    public const CA = 'ca';
+
+    /**
+     * @var string
+     */
+    public const CS = 'cs';
+
+    /**
+     * @var string
+     */
+    public const DA = 'da';
+
+    /**
+     * @var string
+     */
+    public const DE = 'de';
+
+    /**
+     * @var string
+     */
+    public const EN = 'en';
+
+    /**
+     * @var string
+     */
+    public const ES = 'es';
+
+    /**
+     * @var string
+     */
+    public const ET = 'et';
+
+    /**
+     * @var string
+     */
+    public const FA = 'fa';
+
+    /**
+     * @var string
+     */
+    public const FI = 'fi';
+
+    /**
+     * @var string
+     */
+    public const FR = 'fr';
+
+    /**
+     * @var string
+     */
+    public const GR = 'gr';
+
+    /**
+     * @var string
+     */
+    public const HE = 'he';
+
+    /**
+     * @var string
+     */
+    public const HU = 'hu';
+
+    /**
+     * @var string
+     */
+    public const ID = 'id';
+
+    /**
+     * @var string
+     */
+    public const IS = 'is';
+
+    /**
+     * @var string
+     */
+    public const IT = 'it';
+
+    /**
+     * @var string
+     */
+    public const JA = 'ja';
+
+    /**
+     * @var string
+     */
+    public const KA = 'ka';
+
+    /**
+     * @var string
+     */
+    public const KO = 'ko';
+
+    /**
+     * @var string
+     */
+    public const LT = 'lt';
+
+    /**
+     * @var string
+     */
+    public const LV = 'lv';
+
+    /**
+     * @var string
+     */
+    public const NL = 'nl';
+
+    /**
+     * @var string
+     */
+    public const NO = 'no';
+
+    /**
+     * @var string
+     */
+    public const PL = 'pl';
+
+    /**
+     * @var string
+     */
+    public const PT = 'pt';
+
+    /**
+     * @var string
+     */
+    public const RO = 'ro';
+
+    /**
+     * @var string
+     */
+    public const RU = 'ru';
+
+    /**
+     * @var string
+     */
+    public const SV = 'sv';
+
+    /**
+     * @var string
+     */
+    public const SW = 'sw';
+
+    /**
+     * @var string
+     */
+    public const TG = 'tg';
+
+    /**
+     * @var string
+     */
+    public const TH = 'th';
+
+    /**
+     * @var string
+     */
+    public const TR = 'tr';
+
+    /**
+     * @var string
+     */
+    public const UA = 'ua';
+
+    /**
+     * @var string
+     */
+    public const ZH_CN = 'zh-cn';
+
+    /**
+     * @var string
+     */
+    public const ZH_TW = 'zh-tw';
+
+    /**
      * @var []
      * @description: list of supported locales ( check updates here https://github.com/surveyjs/survey-creator/tree/master/src/localization )
      */
     public const LOCALES = [
-        'ar',
-        'bg',
-        'ca',
-        'cs',
-        'da',
-        'de',
-        'en',
-        'es',
-        'et',
-        'fa',
-        'fi',
-        'fr',
-        'gr',
-        'he',
-        'hu',
-        'id',
-        'is',
-        'it',
-        'ja',
-        'ka',
-        'ko',
-        'lt',
-        'lv',
-        'nl',
-        'no',
-        'pl',
-        'pt',
-        'ro',
-        'ru',
-        'sv',
-        'sw',
-        'tg',
-        'th',
-        'tr',
-        'ua',
-        'zh-cn',
-        'zh-tw'
+        self::AR,
+        self::BG,
+        self::CA,
+        self::CS,
+        self::DA,
+        self::DE,
+        self::EN,
+        self::ES,
+        self::ET,
+        self::FA,
+        self::FI,
+        self::FR,
+        self::GR,
+        self::HE,
+        self::HU,
+        self::ID,
+        self::IS,
+        self::IT,
+        self::JA,
+        self::KA,
+        self::KO,
+        self::LT,
+        self::LV,
+        self::NL,
+        self::NO,
+        self::PL,
+        self::PT,
+        self::RO,
+        self::RU,
+        self::SV,
+        self::SW,
+        self::TG,
+        self::TH,
+        self::TR,
+        self::UA,
+        self::ZH_CN,
+        self::ZH_TW
     ];
 }

--- a/src/Model/ChoiceModel.php
+++ b/src/Model/ChoiceModel.php
@@ -10,7 +10,7 @@ class ChoiceModel
     private $value;
 
     /**
-     * @var string
+     * @var TextModel
      */
     private $text;
 
@@ -26,12 +26,12 @@ class ChoiceModel
         return $this;
     }
 
-    public function getText(): string
+    public function getText(): TextModel
     {
         return $this->text;
     }
 
-    public function setText(string $text): self
+    public function setText(TextModel $text): self
     {
         $this->text = $text;
 

--- a/src/Model/Element/ElementAbstract.php
+++ b/src/Model/Element/ElementAbstract.php
@@ -3,6 +3,7 @@
 namespace SurveyJsPhpSdk\Model\Element;
 
 use SurveyJsPhpSdk\Model\ResultModel;
+use SurveyJsPhpSdk\Model\TextModel;
 
 abstract class ElementAbstract implements ElementInterface
 {
@@ -12,7 +13,7 @@ abstract class ElementAbstract implements ElementInterface
     private $name;
 
     /**
-     * @var string
+     * @var TextModel
      */
     private $title;
 
@@ -38,12 +39,12 @@ abstract class ElementAbstract implements ElementInterface
         return $this;
     }
 
-    public function getTitle(): string
+    public function getTitle(): TextModel
     {
         return $this->title;
     }
 
-    public function setTitle(string $title): ElementInterface
+    public function setTitle(TextModel $title): ElementInterface
     {
         $this->title = $title;
 

--- a/src/Model/TextModel.php
+++ b/src/Model/TextModel.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace SurveyJsPhpSdk\Model;
+
+use SurveyJsPhpSdk\Exception\LocaleNotSupportedException;
+use SurveyJsPhpSdk\Localization\Localization;
+
+class TextModel
+{
+    /**
+     * @var object;
+     */
+    private $values;
+
+    public function __construct()
+    {
+        $this->values = (object)[];
+    }
+
+    public function getDefaultValue(): string
+    {
+        return $this->values->default;
+    }
+
+    public function setDefaultValue(string $value): self
+    {
+        $this->values->default = $value;
+
+        return $this;
+    }
+
+    public function getTranslatedValue(string $locale): string
+    {
+        if (!in_array($locale, Localization::LOCALES) || !isset($this->values->$locale)) {
+            return $this->getDefaultValue();
+        }
+
+        return $this->values->$locale;
+    }
+
+    /**
+     * @param string $locale
+     * @param string $value
+     *
+     * @throws LocaleNotSupportedException
+     *
+     * @return TextModel
+     */
+    public function setTranslatedValue(string $locale, string $value): self
+    {
+        if(!in_array($locale, Localization::LOCALES)) {
+            throw new LocaleNotSupportedException($locale);
+        }
+
+        $this->values->$locale = $value;
+        return $this;
+    }
+}

--- a/src/Model/TextModel.php
+++ b/src/Model/TextModel.php
@@ -8,7 +8,12 @@ use SurveyJsPhpSdk\Localization\Localization;
 class TextModel
 {
     /**
-     * @var object;
+     * @var string;
+     */
+    private $default;
+
+    /**
+     * @var TranslationModel[];
      */
     private $values;
 
@@ -19,17 +24,22 @@ class TextModel
 
     public function getDefaultValue(): string
     {
-        return $this->values->default;
+        return $this->default;
     }
 
     public function setDefaultValue(string $value): self
     {
-        $this->values->default = $value;
+        $this->default = $value;
 
         return $this;
     }
 
-    public function getTranslatedValue(string $locale): string
+    /**
+     * @param string $locale
+     *
+     * @return TranslationModel|string
+     */
+    public function getTranslation(string $locale)
     {
         if (!in_array($locale, Localization::LOCALES) || !isset($this->values->$locale)) {
             return $this->getDefaultValue();
@@ -39,20 +49,20 @@ class TextModel
     }
 
     /**
-     * @param string $locale
-     * @param string $value
+     * @param TranslationModel $translation
      *
      * @throws LocaleNotSupportedException
      *
      * @return TextModel
      */
-    public function setTranslatedValue(string $locale, string $value): self
+    public function setTranslation(TranslationModel $translation): self
     {
+        $locale = $translation->getLocale();
         if(!in_array($locale, Localization::LOCALES)) {
             throw new LocaleNotSupportedException($locale);
         }
 
-        $this->values->$locale = $value;
+        $this->values->$locale = $translation;
         return $this;
     }
 }

--- a/src/Model/TranslationModel.php
+++ b/src/Model/TranslationModel.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace SurveyJsPhpSdk\Model;
+
+class TranslationModel
+{
+    /**
+     * @var string;
+     */
+    private $locale;
+
+    /**
+     * @var string;
+     */
+    private $translation;
+
+    public function getLocale(): string
+    {
+        return $this->locale;
+    }
+
+    public function setLocale(string $value): self
+    {
+        $this->locale = $value;
+
+        return $this;
+    }
+
+    public function getTranslation(): string
+    {
+        return $this->translation;
+    }
+
+    public function setTranslation(string $value): self
+    {
+        $this->translation = $value;
+
+        return $this;
+    }
+}

--- a/src/Parser/ChoiceParser.php
+++ b/src/Parser/ChoiceParser.php
@@ -11,8 +11,9 @@ class ChoiceParser
     public function parse(\stdClass $data): ChoiceModel
     {
         $choiceModel = new ChoiceModel();
+        $textParser = new TextParser();
 
-        $choiceModel->setText($data->text);
+        $choiceModel->setText($textParser->parse($data->text));
         $choiceModel->setValue($data->value);
 
         return $choiceModel;

--- a/src/Parser/Element/ChoiceElementParserAbstract.php
+++ b/src/Parser/Element/ChoiceElementParserAbstract.php
@@ -2,8 +2,6 @@
 
 namespace SurveyJsPhpSdk\Parser\Element;
 
-use SurveyJsPhpSdk\Factory\ChoiceFactory;
-use SurveyJsPhpSdk\Model\Element\ChoiceElementAbstract;
 use SurveyJsPhpSdk\Model\Element\ElementInterface;
 use SurveyJsPhpSdk\Parser\ChoiceParser;
 
@@ -31,9 +29,14 @@ abstract class ChoiceElementParserAbstract extends DefaultElementParserAbstract
             $this->element->addChoice($choiceParser->parse($choiceData));
         }
 
-        if(isset($data->otherText)){
+        if (isset($data->otherText)) {
             $this->element->setHasOther(true);
-            $this->element->addChoice($choiceParser->parse($this->formatChoiceObject('other')));
+
+            $this->element->addChoice($choiceParser->parse($this->formatChoiceObject(
+                is_string($data->otherText)
+                    ? 'other'
+                    : (object)['text' => $data->otherText, 'value' => 'other']
+            )));
         }
 
         return $this->element;
@@ -50,12 +53,12 @@ abstract class ChoiceElementParserAbstract extends DefaultElementParserAbstract
     }
 
     /**
-     * @param \stdClass|string $value
+     * @param \stdClass|string|number $value
      *
      * @return \stdClass
      */
     protected function formatChoiceObject($value): \stdClass
     {
-        return ! is_object($value) ? (object)['text' => $value, 'value' => $value] : $value;
+        return !is_object($value) ? (object)['text' => strval($value), 'value' => $value] : $value;
     }
 }

--- a/src/Parser/Element/DefaultElementParserAbstract.php
+++ b/src/Parser/Element/DefaultElementParserAbstract.php
@@ -2,6 +2,8 @@
 
 namespace SurveyJsPhpSdk\Parser\Element;
 
+use SurveyJsPhpSdk\Parser\TextParser;
+
 abstract class DefaultElementParserAbstract extends ElementParserAbstract
 {
 
@@ -10,7 +12,8 @@ abstract class DefaultElementParserAbstract extends ElementParserAbstract
         parent::configure($data);
 
         if (isset($data->title)) {
-            $this->element->setTitle($data->title);
+            $textParser = new TextParser();
+            $this->element->setTitle($textParser->parse($data->title));
         }
 
         if (isset($data->isRequired)) {

--- a/src/Parser/Element/RatingElementParser.php
+++ b/src/Parser/Element/RatingElementParser.php
@@ -24,10 +24,7 @@ class RatingElementParser extends ChoiceElementParserAbstract
             }
 
             for ($i = 1; $i <= $max; $i++) {
-                $choicesData[] = (object)[
-                    'text'  => $i,
-                    'value' => $i
-                ];
+                $choicesData[] = $this->formatChoiceObject($i);
             }
         } else {
             foreach ($data->rateValues as $value) {

--- a/src/Parser/TextParser.php
+++ b/src/Parser/TextParser.php
@@ -27,7 +27,10 @@ class TextParser
 
         if(is_object($data)) {
             foreach (Localization::LOCALES as $supportedLocale) {
-                $data->$supportedLocale && $textModel->setTranslatedValue($supportedLocale, $data->$supportedLocale);
+                $translationParser = new TranslationParser();
+                $data->$supportedLocale && $textModel->setTranslation(
+                    $translationParser->parse($supportedLocale, $data->$supportedLocale)
+                );
             }
         }
 

--- a/src/Parser/TextParser.php
+++ b/src/Parser/TextParser.php
@@ -3,6 +3,7 @@
 
 namespace SurveyJsPhpSdk\Parser;
 
+use SurveyJsPhpSdk\Exception\LocaleNotSupportedException;
 use SurveyJsPhpSdk\Localization\Localization;
 use SurveyJsPhpSdk\Model\TextModel;
 
@@ -26,10 +27,18 @@ class TextParser
         $textModel->setDefaultValue(is_string($data) ? $data : $data->default ?? '');
 
         if(is_object($data)) {
-            foreach (Localization::LOCALES as $supportedLocale) {
+            $arrayData = get_object_vars($data);
+            unset($arrayData['default']);
+
+            foreach ($arrayData as $locale => $translation) {
                 $translationParser = new TranslationParser();
-                $data->$supportedLocale && $textModel->setTranslation(
-                    $translationParser->parse($supportedLocale, $data->$supportedLocale)
+
+                if(!in_array($locale, Localization::LOCALES)) {
+                    throw new LocaleNotSupportedException($locale);
+                }
+
+                $textModel->setTranslation(
+                    $translationParser->parse($locale, $translation)
                 );
             }
         }

--- a/src/Parser/TextParser.php
+++ b/src/Parser/TextParser.php
@@ -1,0 +1,36 @@
+<?php
+
+
+namespace SurveyJsPhpSdk\Parser;
+
+use SurveyJsPhpSdk\Localization\Localization;
+use SurveyJsPhpSdk\Model\TextModel;
+
+class TextParser
+{
+
+    /**
+     * @param object|string $data
+     *
+     *
+     * @return TextModel
+     */
+    public function parse($data): TextModel
+    {
+        if (!is_string($data) && !is_object($data)) {
+            throw new \InvalidArgumentException('$data must be a string or an object.');
+        }
+
+        $textModel = new TextModel();
+
+        $textModel->setDefaultValue(is_string($data) ? $data : $data->default ?? '');
+
+        if(is_object($data)) {
+            foreach (Localization::LOCALES as $supportedLocale) {
+                $data->$supportedLocale && $textModel->setTranslatedValue($supportedLocale, $data->$supportedLocale);
+            }
+        }
+
+        return $textModel;
+    }
+}

--- a/src/Parser/TranslationParser.php
+++ b/src/Parser/TranslationParser.php
@@ -1,0 +1,20 @@
+<?php
+
+
+namespace SurveyJsPhpSdk\Parser;
+
+use SurveyJsPhpSdk\Model\TranslationModel;
+
+class TranslationParser
+{
+
+    public function parse(string $locale, string $translation): TranslationModel
+    {
+        $translationModel = new TranslationModel();
+
+        $translationModel->setLocale($locale);
+        $translationModel->setTranslation($translation);
+
+        return $translationModel;
+    }
+}

--- a/tests/Model/RatingElementTest.php
+++ b/tests/Model/RatingElementTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use SurveyJsPhpSdk\Model\ChoiceModel;
 use SurveyJsPhpSdk\Model\Element\RatingElement;
 use SurveyJsPhpSdk\Model\ResultModel;
+use SurveyJsPhpSdk\Parser\TextParser;
 
 class RatingElementTest extends TestCase
 {
@@ -17,15 +18,21 @@ class RatingElementTest extends TestCase
      */
     private $rating;
 
+    /**
+     * @var TextParser
+     */
+    private $textParser;
+
     protected function setUp()
     {
+        $this->textParser = new TextParser();
         $this->rating = new RatingElement();
         $this->rating->setName('Great rating question');
 
         $choice1 = new ChoiceModel();
-        $choice1->setText('1')->setValue('1');
+        $choice1->setText($this->textParser->parse('1'))->setValue('1');
         $choice2 = new ChoiceModel();
-        $choice2->setText('2')->setValue('2');
+        $choice2->setText($this->textParser->parse('2'))->setValue('2');
 
         $this->rating->addChoice($choice1);
         $this->rating->addChoice($choice2);

--- a/tests/Model/TextModelTest.php
+++ b/tests/Model/TextModelTest.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace SurveyJsPhpSdk\Tests\Model;
+
+use PHPUnit\Framework\TestCase;
+use SurveyJsPhpSdk\Exception\LocaleNotSupportedException;
+use SurveyJsPhpSdk\Model\TextModel;
+
+class TextModelTest extends TestCase
+{
+    /**
+     * @var TextModel
+     */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new TextModel();
+    }
+
+    public function testParseRaiseException()
+    {
+        $this->expectException(LocaleNotSupportedException::class);
+        $this->expectExceptionMessage('Locale "NOT_SUPPORTED_LOCALE" is not supported');
+        $this->sut->setTranslatedValue('NOT_SUPPORTED_LOCALE', 'text');
+    }
+}

--- a/tests/Model/TextModelTest.php
+++ b/tests/Model/TextModelTest.php
@@ -5,6 +5,7 @@ namespace SurveyJsPhpSdk\Tests\Model;
 use PHPUnit\Framework\TestCase;
 use SurveyJsPhpSdk\Exception\LocaleNotSupportedException;
 use SurveyJsPhpSdk\Model\TextModel;
+use SurveyJsPhpSdk\Parser\TranslationParser;
 
 class TextModelTest extends TestCase
 {
@@ -20,8 +21,11 @@ class TextModelTest extends TestCase
 
     public function testParseRaiseException()
     {
+        $translationParser = new TranslationParser();
         $this->expectException(LocaleNotSupportedException::class);
-        $this->expectExceptionMessage('Locale "NOT_SUPPORTED_LOCALE" is not supported');
-        $this->sut->setTranslatedValue('NOT_SUPPORTED_LOCALE', 'text');
+        $this->expectExceptionMessage('Locale "NOT_SUPPORTED_LANG" is not supported');
+        $this->sut->setTranslation(
+            $translationParser->parse('NOT_SUPPORTED_LANG', 'translation')
+        );
     }
 }

--- a/tests/Parser/ChoiceParserTest.php
+++ b/tests/Parser/ChoiceParserTest.php
@@ -34,7 +34,7 @@ class ChoiceParserTest extends TestCase
         $model = $this->sut->parse($this->choice);
 
         $this->assertInstanceOf(ChoiceModel::class, $model);
-        $this->assertEquals('some_text', $model->getText());
+        $this->assertEquals('some_text', $model->getText()->getDefaultValue());
         $this->assertEquals('some_value', $model->getValue());
     }
 }

--- a/tests/Parser/Element/CheckboxElementParserTest.php
+++ b/tests/Parser/Element/CheckboxElementParserTest.php
@@ -7,6 +7,8 @@ use PHPUnit\Framework\TestCase;
 use SurveyJsPhpSdk\Factory\ElementFactory;
 use SurveyJsPhpSdk\Model\ChoiceModel;
 use SurveyJsPhpSdk\Model\Element\CheckboxElement;
+use SurveyJsPhpSdk\Model\TextModel;
+use SurveyJsPhpSdk\Model\TranslationModel;
 use SurveyJsPhpSdk\Parser\Element\CheckboxElementParser;
 
 class CheckboxElementParserTest extends TestCase
@@ -84,6 +86,7 @@ class CheckboxElementParserTest extends TestCase
 
         $this->assertInstanceOf(CheckboxElement::class, $model);
         $this->assertEquals($element->name, $model->getName());
+        $this->assertInstanceOf(TextModel::class, $model->getTitle());
         $this->assertEquals($element->title, $model->getTitle()->getDefaultValue());
         $this->assertEquals($element->isRequired, $model->isRequired());
         $this->assertEquals($element->enableIf, $model->getEnableIf());
@@ -94,6 +97,7 @@ class CheckboxElementParserTest extends TestCase
         }
 
         $this->assertEquals(1+count($element->choices), count($choices));
+        $this->assertInstanceOf(TextModel::class, end($choices)->getText());
         $this->assertEquals('other', end($choices)->getText()->getDefaultValue());
     }
 
@@ -105,8 +109,10 @@ class CheckboxElementParserTest extends TestCase
 
         $this->assertInstanceOf(CheckboxElement::class, $model);
         $this->assertEquals($element->name, $model->getName());
+        $this->assertInstanceOf(TextModel::class, $model->getTitle());
         $this->assertEquals($element->title->default, $model->getTitle()->getDefaultValue());
-        $this->assertEquals($element->title->en, $model->getTitle()->getTranslatedValue('en'));
+        $this->assertInstanceOf(TranslationModel::class, $model->getTitle()->getTranslation('en'));
+        $this->assertEquals($element->title->en, $model->getTitle()->getTranslation('en')->getTranslation());
         $this->assertEquals($element->isRequired, $model->isRequired());
         $this->assertEquals($element->enableIf, $model->getEnableIf());
         $this->assertTrue($model->hasOther());
@@ -116,6 +122,7 @@ class CheckboxElementParserTest extends TestCase
         }
 
         $this->assertEquals(1+count($element->choices), count($choices));
+        $this->assertInstanceOf(TextModel::class, end($choices)->getText());
         $this->assertEquals($element->otherText->default, end($choices)->getText()->getDefaultValue());
     }
 
@@ -134,6 +141,7 @@ class CheckboxElementParserTest extends TestCase
 
         foreach ($choices as $choice) {
             $this->assertInstanceOf(ChoiceModel::class, $choice);
+            $this->assertInstanceOf(TextModel::class, $choice->getText());
         }
 
         $this->assertEquals(count($element->choices), count($choices));

--- a/tests/Parser/Element/CommentElementParserTest.php
+++ b/tests/Parser/Element/CommentElementParserTest.php
@@ -8,6 +8,7 @@ use PHPStan\Testing\TestCase;
 use SurveyJsPhpSdk\Exception\ElementNameNotFoundException;
 use SurveyJsPhpSdk\Factory\ElementFactory;
 use SurveyJsPhpSdk\Model\Element\CommentElement;
+use SurveyJsPhpSdk\Model\TranslationModel;
 use SurveyJsPhpSdk\Parser\Element\CommentElementParser;
 
 class CommentElementParserTest extends TestCase
@@ -57,7 +58,8 @@ class CommentElementParserTest extends TestCase
         $this->assertInstanceOf(CommentElement::class, $model);
         $this->assertEquals($this->element->name, $model->getName());
         $this->assertEquals($this->element->title->default, $model->getTitle()->getDefaultValue());
-        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslatedValue('en'));
+        $this->assertInstanceOf(TranslationModel::class, $model->getTitle()->getTranslation('en'));
+        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslation('en')->getTranslation());
         $this->assertEquals($this->element->isRequired, $model->isRequired());
         $this->assertEquals($this->element->enableIf, $model->getEnableIf());
     }

--- a/tests/Parser/Element/CommentElementParserTest.php
+++ b/tests/Parser/Element/CommentElementParserTest.php
@@ -41,7 +41,23 @@ class CommentElementParserTest extends TestCase
 
         $this->assertInstanceOf(CommentElement::class, $model);
         $this->assertEquals($this->element->name, $model->getName());
-        $this->assertEquals($this->element->title, $model->getTitle());
+        $this->assertEquals($this->element->title, $model->getTitle()->getDefaultValue());
+        $this->assertEquals($this->element->isRequired, $model->isRequired());
+        $this->assertEquals($this->element->enableIf, $model->getEnableIf());
+    }
+
+    public function testParseSuccessWithTranslation()
+    {
+        $this->element->title = (object)[
+            'default' => 'def title',
+            'en' => 'en title'
+        ];
+        $model  = $this->sut->parse($this->element);
+
+        $this->assertInstanceOf(CommentElement::class, $model);
+        $this->assertEquals($this->element->name, $model->getName());
+        $this->assertEquals($this->element->title->default, $model->getTitle()->getDefaultValue());
+        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslatedValue('en'));
         $this->assertEquals($this->element->isRequired, $model->isRequired());
         $this->assertEquals($this->element->enableIf, $model->getEnableIf());
     }

--- a/tests/Parser/Element/RadioGroupElementParserTest.php
+++ b/tests/Parser/Element/RadioGroupElementParserTest.php
@@ -30,7 +30,10 @@ class RadioGroupElementParserTest extends TestCase
         ];
 
         $choice2 = (object)[
-            'text'  => 'choice 2',
+            'text'  => (object)[
+                'default' => 'choice 2',
+                'it' => 'opzione 2'
+            ],
             'value' => '2'
         ];
 
@@ -54,7 +57,28 @@ class RadioGroupElementParserTest extends TestCase
 
         $this->assertInstanceOf(RadiogroupElement::class, $model);
         $this->assertEquals($this->element->name, $model->getName());
-        $this->assertEquals($this->element->title, $model->getTitle());
+        $this->assertEquals($this->element->title, $model->getTitle()->getDefaultValue());
+        $this->assertEquals($this->element->isRequired, $model->isRequired());
+        $this->assertEquals($this->element->enableIf, $model->getEnableIf());
+        $this->assertTrue($model->hasOther());
+
+        foreach($model->getChoices() as $choice){
+            $this->assertInstanceOf(ChoiceModel::class, $choice);
+        }
+    }
+
+    public function testParseSuccessWithTranslation()
+    {
+        $this->element->title = (object)[
+            'default' => 'def title',
+            'en' => 'en title'
+        ];
+        $model = $this->sut->parse($this->element);
+
+        $this->assertInstanceOf(RadiogroupElement::class, $model);
+        $this->assertEquals($this->element->name, $model->getName());
+        $this->assertEquals($this->element->title->default, $model->getTitle()->getDefaultValue());
+        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslatedValue('en'));
         $this->assertEquals($this->element->isRequired, $model->isRequired());
         $this->assertEquals($this->element->enableIf, $model->getEnableIf());
         $this->assertTrue($model->hasOther());

--- a/tests/Parser/Element/RadioGroupElementParserTest.php
+++ b/tests/Parser/Element/RadioGroupElementParserTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\TestCase;
 use SurveyJsPhpSdk\Factory\ElementFactory;
 use SurveyJsPhpSdk\Model\ChoiceModel;
 use SurveyJsPhpSdk\Model\Element\RadioGroupElement;
+use SurveyJsPhpSdk\Model\TextModel;
 use SurveyJsPhpSdk\Parser\Element\RadioGroupElementParser;
 
 class RadioGroupElementParserTest extends TestCase
@@ -64,6 +65,7 @@ class RadioGroupElementParserTest extends TestCase
 
         foreach($model->getChoices() as $choice){
             $this->assertInstanceOf(ChoiceModel::class, $choice);
+            $this->assertInstanceOf(TextModel::class, $choice->getText());
         }
     }
 
@@ -78,13 +80,14 @@ class RadioGroupElementParserTest extends TestCase
         $this->assertInstanceOf(RadiogroupElement::class, $model);
         $this->assertEquals($this->element->name, $model->getName());
         $this->assertEquals($this->element->title->default, $model->getTitle()->getDefaultValue());
-        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslatedValue('en'));
+        $this->assertEquals($this->element->title->en, $model->getTitle()->getTranslation('en')->getTranslation());
         $this->assertEquals($this->element->isRequired, $model->isRequired());
         $this->assertEquals($this->element->enableIf, $model->getEnableIf());
         $this->assertTrue($model->hasOther());
 
         foreach($model->getChoices() as $choice){
             $this->assertInstanceOf(ChoiceModel::class, $choice);
+            $this->assertInstanceOf(TextModel::class, $choice->getText());
         }
     }
 }

--- a/tests/Parser/Element/RatingElementParserTest.php
+++ b/tests/Parser/Element/RatingElementParserTest.php
@@ -8,6 +8,7 @@ use SurveyJsPhpSdk\Factory\ElementFactory;
 use SurveyJsPhpSdk\Model\ChoiceModel;
 use SurveyJsPhpSdk\Model\Element\RatingElement;
 use SurveyJsPhpSdk\Model\TextModel;
+use SurveyJsPhpSdk\Model\TranslationModel;
 use SurveyJsPhpSdk\Parser\Element\RatingElementParser;
 
 class RatingElementParserTest extends TestCase
@@ -31,7 +32,8 @@ class RatingElementParserTest extends TestCase
 
         $choiceWithTranslation = (object)[
             'text' => (object)[
-                'default' => 'choise 5'
+                'default' => 'choise 5',
+                'en' => 'opt 5'
             ],
             'value' => '5'
         ];
@@ -49,7 +51,8 @@ class RatingElementParserTest extends TestCase
             'type'         => ElementFactory::RATING_TYPE,
             'name'         => 'element_2',
             'title'        => (object)[
-                'default' => 'Element 2'
+                'default' => 'Element 2',
+                'en' => 'title en'
             ],
             'isRequired'   => false,
             'enableIf'     => 'implausible conditions',
@@ -78,7 +81,10 @@ class RatingElementParserTest extends TestCase
             if (is_string($element->title)) {
                 $this->assertEquals($element->title, $model->getTitle()->getDefaultValue());
             } else {
+                $this->assertInstanceOf(TextModel::class, $model->getTitle());
+                $this->assertInstanceOf(TranslationModel::class, $model->getTitle()->getTranslation('en'));
                 $this->assertEquals($element->title->default, $model->getTitle()->getDefaultValue());
+                $this->assertEquals($element->title->en, $model->getTitle()->getTranslation('en')->getTranslation());
             }
             $this->assertEquals($element->isRequired, $model->isRequired());
             $this->assertEquals($element->enableIf, $model->getEnableIf());

--- a/tests/Parser/SurveyTemplateParserTest.php
+++ b/tests/Parser/SurveyTemplateParserTest.php
@@ -12,9 +12,12 @@ use SurveyJsPhpSdk\Exception\MissingElementConfigurationException;
 use SurveyJsPhpSdk\Exception\PageDataNotFoundException;
 use SurveyJsPhpSdk\Model\ChoiceModel;
 use SurveyJsPhpSdk\Model\Element\ChoiceElementAbstract;
+use SurveyJsPhpSdk\Model\Element\CommentElement;
 use SurveyJsPhpSdk\Model\Element\ElementInterface;
 use SurveyJsPhpSdk\Model\PageModel;
 use SurveyJsPhpSdk\Model\TemplateModel;
+use SurveyJsPhpSdk\Model\TextModel;
+use SurveyJsPhpSdk\Model\TranslationModel;
 use SurveyJsPhpSdk\Parser\TemplateParser;
 use SurveyJsPhpSdk\Tests\Fake\FakeCustomElementConfiguration;
 use SurveyJsPhpSdk\Tests\Fake\FakeCustomElementModel;
@@ -76,6 +79,94 @@ class SurveyTemplateParserTest extends TestCase
                         }
                       ],
                       "choicesOrder": "asc"
+                    }
+                  ]
+                }
+              ],
+              "showNavigationButtons": "none",
+              "showPageTitles": false,
+              "showCompletedPage": false,
+              "showQuestionNumbers": "off"
+            }';
+
+    private $testCaseSuccessWithTranslation = '
+    {
+              "pages": [
+                {
+                  "name": "page1",
+                  "elements": [
+                    {
+                      "type": "radiogroup",
+                      "name": "question1",
+                      "title": {
+                        "default": "First Question",
+                        "it": "Prima domanda"
+                      },
+                      "isRequired": true,
+                      "choices": [
+                        {
+                          "value": "1",
+                          "text": {
+                            "default": "good",
+                            "it": "bene"
+                          }
+                        },
+                        {
+                          "value": "2",
+                          "text": {
+                            "default": "bad",
+                            "it": "male"
+                          }
+                        }
+                      ],
+                      "choicesOrder": "asc"
+                    },
+                    {
+                      "type": "custom_test_element_type",
+                      "name": "question2"
+                    }
+                  ]
+                },
+                {
+                  "name": "page2",
+                  "elements": [
+                    {
+                      "type": "comment",
+                      "name": "question3",
+                      "title":  {
+                        "default": "question3",
+                        "it": "domanda 3"
+                      },
+                      "enableIf": "{question2} notempty"
+                    },
+                    {
+                      "type": "radiogroup",
+                      "name": "question4",
+                      "title":  {
+                        "default": "Fourth Question",
+                        "it": "domanda 4"
+                      },
+                      "choices": [
+                        {
+                          "value": "1",
+                          "text": {
+                            "default": "yes",
+                            "it": "si"
+                          }
+                        },
+                        {
+                          "value": "2",
+                          "text": {
+                            "default": "no",
+                            "it": "no"
+                          }
+                        }
+                      ],
+                      "choicesOrder": "asc",
+                      "otherText": {
+                        "default": "other",
+                        "it": "altro"
+                      }
                     }
                   ]
                 }
@@ -173,6 +264,40 @@ class SurveyTemplateParserTest extends TestCase
 
                     foreach($element->getChoices() as $choice){
                         $this->assertInstanceOf(ChoiceModel::class, $choice);
+                    }
+                }
+            }
+        }
+    }
+
+    public function testParseSuccessWithTranslations(){
+        $model = $this->sut->parse($this->testCaseSuccessWithTranslation);
+
+        $this->assertInstanceOf(TemplateModel::class, $model);
+        $this->assertEquals('none', $model->getShowNavigationButtons());
+        $this->assertEquals(false, $model->isShowPageTitles());
+        $this->assertEquals(false, $model->isShowCompletedPage());
+        $this->assertEquals('off', $model->getShowQuestionNumbers());
+
+        foreach($model->getPages() as $page){
+
+            $this->assertInstanceOf(PageModel::class, $page);
+
+            foreach($page->getElements() as $element){
+
+                $this->assertInstanceOf(ElementInterface::class, $element);
+
+                if($element instanceof ChoiceElementAbstract || $element instanceof CommentElement){
+                    $this->assertInstanceOf(TextModel::class, $element->getTitle());
+                    $this->assertInstanceOf(TranslationModel::class, $element->getTitle()->getTranslation('it'));
+                }
+
+                if($element instanceof ChoiceElementAbstract){
+
+                    foreach($element->getChoices() as $choice){
+                        $this->assertInstanceOf(ChoiceModel::class, $choice);
+                        $this->assertInstanceOf(TextModel::class, $choice->getText());
+                        $this->assertInstanceOf(TranslationModel::class, $choice->getText()->getTranslation('it'));
                     }
                 }
             }

--- a/tests/Parser/TextParserTest.php
+++ b/tests/Parser/TextParserTest.php
@@ -1,0 +1,74 @@
+<?php
+
+
+namespace SurveyJsPhpSdk\Tests\Parser;
+
+
+use PHPUnit\Framework\TestCase;
+use SurveyJsPhpSdk\Model\TextModel;
+use SurveyJsPhpSdk\Parser\TextParser;
+
+class TextParserTest extends TestCase
+{
+    /**
+     * @var object|string
+     */
+    private $text;
+    /**
+     * @var TextParser
+     */
+    private $sut;
+
+    protected function setUp()
+    {
+        $this->sut = new TextParser();
+    }
+
+    public function testParseSuccessWithDefaultValue()
+    {
+        $this->text = (object)[
+            'default' => 'def text',
+            'it' => 'it text'
+        ];
+
+        $model = $this->sut->parse($this->text);
+
+        $this->assertInstanceOf(TextModel::class, $model);
+        $this->assertEquals('def text', $model->getDefaultValue());
+        $this->assertEquals('it text', $model->getTranslatedValue('it'));
+        $this->assertEquals('def text', $model->getTranslatedValue('wrong_locale'));
+    }
+
+    public function testParseSuccessWithoutDefaultValue()
+    {
+        $this->text = (object)[
+            'it' => 'it text'
+        ];
+
+        $model = $this->sut->parse($this->text);
+
+        $this->assertInstanceOf(TextModel::class, $model);
+        $this->assertEquals('', $model->getDefaultValue());
+        $this->assertEquals('it text', $model->getTranslatedValue('it'));
+        $this->assertEquals('', $model->getTranslatedValue('wrong_locale'));
+    }
+
+    public function testParseSuccessWithString()
+    {
+        $this->text = 'def text';
+
+        $model = $this->sut->parse($this->text);
+
+        $this->assertInstanceOf(TextModel::class, $model);
+        $this->assertEquals('def text', $model->getDefaultValue());
+        $this->assertEquals('def text', $model->getTranslatedValue('it'));
+        $this->assertEquals('def text', $model->getTranslatedValue('wrong_locale'));
+    }
+
+    public function testParseRaiseException()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('$data must be a string or an object.');
+        $this->sut->parse(false);
+    }
+}

--- a/tests/Parser/TextParserTest.php
+++ b/tests/Parser/TextParserTest.php
@@ -5,6 +5,7 @@ namespace SurveyJsPhpSdk\Tests\Parser;
 
 
 use PHPUnit\Framework\TestCase;
+use SurveyJsPhpSdk\Exception\LocaleNotSupportedException;
 use SurveyJsPhpSdk\Model\TextModel;
 use SurveyJsPhpSdk\Parser\TextParser;
 
@@ -65,10 +66,21 @@ class TextParserTest extends TestCase
         $this->assertEquals('def text', $model->getTranslation('wrong_locale'));
     }
 
-    public function testParseRaiseException()
+    public function testParseRaiseInvalidArgumentException()
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('$data must be a string or an object.');
         $this->sut->parse(false);
+    }
+
+    public function testParseRaiseLocaleNotSupportedException()
+    {
+        $this->text = (object)[
+            'NOT_SUPPORTED_LANG' => 'it text'
+        ];
+
+        $this->expectException(LocaleNotSupportedException::class);
+        $this->expectExceptionMessage('Locale "NOT_SUPPORTED_LANG" is not supported');
+        $this->sut->parse($this->text);
     }
 }

--- a/tests/Parser/TextParserTest.php
+++ b/tests/Parser/TextParserTest.php
@@ -35,8 +35,8 @@ class TextParserTest extends TestCase
 
         $this->assertInstanceOf(TextModel::class, $model);
         $this->assertEquals('def text', $model->getDefaultValue());
-        $this->assertEquals('it text', $model->getTranslatedValue('it'));
-        $this->assertEquals('def text', $model->getTranslatedValue('wrong_locale'));
+        $this->assertEquals('it text', $model->getTranslation('it')->getTranslation());
+        $this->assertEquals('def text', $model->getTranslation('wrong_locale'));
     }
 
     public function testParseSuccessWithoutDefaultValue()
@@ -49,8 +49,8 @@ class TextParserTest extends TestCase
 
         $this->assertInstanceOf(TextModel::class, $model);
         $this->assertEquals('', $model->getDefaultValue());
-        $this->assertEquals('it text', $model->getTranslatedValue('it'));
-        $this->assertEquals('', $model->getTranslatedValue('wrong_locale'));
+        $this->assertEquals('it text', $model->getTranslation('it')->getTranslation());
+        $this->assertEquals('', $model->getTranslation('wrong_locale'));
     }
 
     public function testParseSuccessWithString()
@@ -61,8 +61,8 @@ class TextParserTest extends TestCase
 
         $this->assertInstanceOf(TextModel::class, $model);
         $this->assertEquals('def text', $model->getDefaultValue());
-        $this->assertEquals('def text', $model->getTranslatedValue('it'));
-        $this->assertEquals('def text', $model->getTranslatedValue('wrong_locale'));
+        $this->assertEquals('def text', $model->getTranslation('it'));
+        $this->assertEquals('def text', $model->getTranslation('wrong_locale'));
     }
 
     public function testParseRaiseException()


### PR DESCRIPTION
Goal of this PR is to allow use of texts with translations inside the survey template.

This pull request doesn't cause breaking changes

Example of survey JSON with translations
`{
  "pages": [
    {
      "name": "pagina1",
      "elements": [
        {
          "type": "rating",
          "name": "domanda1",
          "title": {
            "default": "domanda 1",
            "en": "question 1"
          },
          "rateValues": [
            {
              "value": "1",
              "text": {
                "default": "uno",
                "en": "one"
              }
            },
            {
              "value": "2",
              "text": "2"
            },
            "3",
            "4",
            "5"
          ],
          "rateMax": 5
        },
        {
          "type": "radiogroup",
          "name": "domanda2",
          "title": {
            "default": "domanda 2",
            "en": "question 2"
          },
          "choices": [
            {
              "value": "Elemento1",
              "text": {
                "default": "elemento 1",
                "en": "element 1"
              }
            },
            {
              "value": "Elemento2",
              "text": {
                "default": "elemento 2",
                "en": "element 2"
              }
            },
            {
              "value": "Elemento3",
              "text": {
                "default": "elemento 3",
              }
            }
          ],
          "hasOther": true,
          "otherText": {
            "default": "altro",
            "en": "other"
          }
        }
      ]
    }
  ],
  "showNavigationButtons": "none",
  "showPageTitles": false,
  "showCompletedPage": "off",
  "showQuestionNumbers": "off"
}`